### PR TITLE
feat: implementar geracao real de skills

### DIFF
--- a/a3x/skills/skill_creator.py
+++ b/a3x/skills/skill_creator.py
@@ -1,161 +1,178 @@
-"""
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from typing import Tuple
+
+from a3x.meta_capabilities import SkillProposal
+
+
 class SkillCreator:
     """Creates actual skill implementations from proposals."""
-    
+
     def __init__(self, workspace_root: Path) -> None:
         self.workspace_root = workspace_root
         self.skills_dir = workspace_root / "a3x" / "skills"
         self.skills_dir.mkdir(parents=True, exist_ok=True)
-    
+
     def create_skill_from_proposal(self, proposal: SkillProposal) -> Tuple[bool, str]:
-        """
-        Create an actual skill implementation from a proposal.
-        Returns (success, message).
-        """
+        """Create an actual skill implementation from a proposal."""
         try:
-            # Generate the skill implementation code
             implementation = self._generate_skill_implementation(proposal)
-            
-            # Save the skill to a file
-            skill_filename = f"{proposal.name.lower().replace(' ', '_').replace('-', '_')}.py"
+
+            skill_filename = (
+                f"{proposal.name.lower().replace(' ', '_').replace('-', '_')}.py"
+            )
             skill_path = self.skills_dir / skill_filename
-            
-            # Write the implementation to file
             skill_path.write_text(implementation, encoding="utf-8")
-            
-            # Create test file for the new skill
-            test_filename = f"test_{proposal.name.lower().replace(' ', '_').replace('-', '_')}.py"
-            test_path = self.workspace_root / "tests" / "unit" / "a3x" / "skills" / test_filename
+
+            test_filename = (
+                f"test_{proposal.name.lower().replace(' ', '_').replace('-', '_')}.py"
+            )
+            test_path = (
+                self.workspace_root
+                / "tests"
+                / "unit"
+                / "a3x"
+                / "skills"
+                / test_filename
+            )
             test_path.parent.mkdir(parents=True, exist_ok=True)
-            
+
             test_implementation = self._generate_skill_test(proposal, skill_filename)
             test_path.write_text(test_implementation, encoding="utf-8")
-            
+
             return True, f"Skill '{proposal.name}' created successfully at {skill_path}"
-            
-        except Exception as e:
-            return False, f"Failed to create skill '{proposal.name}': {str(e)}"
-    
+        except Exception as exc:  # pragma: no cover - defensive branch
+            return False, f"Failed to create skill '{proposal.name}': {exc}"
+
     def _generate_skill_implementation(self, proposal: SkillProposal) -> str:
         """Generate the actual implementation code for a skill."""
-        # Create a basic skill template
-        implementation = f'''"""{proposal.description}"""
+        class_name = proposal.name.replace(" ", "").replace("-", "")
+        implementation = dedent(
+            f'''
+            """{proposal.description}"""
 
-from __future__ import annotations
+            from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional
-from pathlib import Path
+            from dataclasses import dataclass, field
+            from typing import Dict, List, Optional
+            from pathlib import Path
 
-from ..actions import AgentAction, Observation
-from ..config import AgentConfig
+            from ..actions import AgentAction, Observation
+            from ..config import AgentConfig
 
 
-@dataclass
-class {proposal.name.replace(" ", "").replace("-", "")}:
-    """{proposal.description}"""
-    
-    config: AgentConfig
-    # Add skill-specific fields based on proposal
-    capabilities: List[str] = field(default_factory=list)
-    
-    def __post_init__(self) -> None:
-        """Initialize skill-specific components."""
-        self._initialize_components()
-    
-    def _initialize_components(self) -> None:
-        """Initialize skill-specific components."""
-        # Implementation goes here based on proposal requirements
-        pass
-    
-    def execute(self, action: AgentAction) -> Observation:
-        """Execute the skill."""
-        try:
-            # Implementation based on proposal
-            result = self._perform_action(action)
-            return Observation(success=True, output=result)
-        except Exception as e:
-            return Observation(success=False, error=str(e))
-    
-    def _perform_action(self, action: AgentAction) -> str:
-        """Perform the specific action for this skill."""
-        # Actual implementation would go here
-        # For now, return a placeholder result
-        return f"Executed {proposal.name} with action: {action.text or 'no text'}"
-    
-    def analyze(self, data: Dict[str, any]) -> Dict[str, any]:
-        """Analyze data related to this skill."""
-        # Analysis implementation based on proposal
-        return {"analysis_result": "placeholder"}
-    
-    def suggest_improvements(self) -> List[str]:
-        """Suggest improvements for this skill."""
-        # Improvement suggestions based on proposal
-        return ["Implement core functionality", "Add more comprehensive tests"]
+            @dataclass
+            class {class_name}:
+                """{proposal.description}"""
 
-'''
-        return implementation
-    
+                config: AgentConfig
+                # Add skill-specific fields based on proposal
+                capabilities: List[str] = field(default_factory=list)
+
+                def __post_init__(self) -> None:
+                    """Initialize skill-specific components."""
+                    self._initialize_components()
+
+                def _initialize_components(self) -> None:
+                    """Initialize skill-specific components."""
+                    # Implementation goes here based on proposal requirements
+                    pass
+
+                def execute(self, action: AgentAction) -> Observation:
+                    """Execute the skill."""
+                    try:
+                        # Implementation based on proposal
+                        result = self._perform_action(action)
+                        return Observation(success=True, output=result)
+                    except Exception as exc:  # pragma: no cover - placeholder logic
+                        return Observation(success=False, error=str(exc))
+
+                def _perform_action(self, action: AgentAction) -> str:
+                    """Perform the specific action for this skill."""
+                    # Actual implementation would go here
+                    # For now, return a placeholder result
+                    return (
+                        f"Executed {proposal.name} with action: "
+                        f"{{action.text or 'no text'}}"
+                    )
+
+                def analyze(self, data: Dict[str, any]) -> Dict[str, any]:
+                    """Analyze data related to this skill."""
+                    # Analysis implementation based on proposal
+                    return {{"analysis_result": "placeholder"}}
+
+                def suggest_improvements(self) -> List[str]:
+                    """Suggest improvements for this skill."""
+                    # Improvement suggestions based on proposal
+                    return ["Implement core functionality", "Add more comprehensive tests"]
+            '''
+        ).strip("\n")
+        return f"{implementation}\n"
+
     def _generate_skill_test(self, proposal: SkillProposal, skill_filename: str) -> str:
         """Generate a test file for the skill."""
         skill_class_name = proposal.name.replace(" ", "").replace("-", "")
-        test_implementation = f'''"""Tests for {proposal.name} skill."""
+        test_implementation = dedent(
+            f'''
+            """Tests for {proposal.name} skill."""
 
-import pytest
-from unittest.mock import Mock, patch
-from pathlib import Path
+            import pytest
+            from unittest.mock import Mock, patch
+            from pathlib import Path
 
-from a3x.skills.{skill_filename[:-3]} import {skill_class_name}
-from a3x.actions import AgentAction, ActionType, Observation
-from a3x.config import AgentConfig
+            from a3x.skills.{skill_filename[:-3]} import {skill_class_name}
+            from a3x.actions import AgentAction, ActionType, Observation
+            from a3x.config import AgentConfig
 
 
-class Test{skill_class_name}:
-    """Tests for {proposal.name}."""
-    
-    def setup_method(self) -> None:
-        """Setup before each test."""
-        self.mock_config = Mock(spec=AgentConfig)
-        self.mock_config.workspace = Mock()
-        self.mock_config.workspace.root = Path("/tmp/test")
-        self.mock_config.policies = Mock()
-        self.mock_config.policies.allow_network = False
-        self.mock_config.policies.deny_commands = []
-        self.mock_config.audit = Mock()
-        self.mock_config.audit.enable_file_log = True
-        self.mock_config.audit.file_dir = Path("seed/changes")
-        self.mock_config.audit.enable_git_commit = False
-        self.mock_config.audit.commit_prefix = "A3X"
-        self.skill = {skill_class_name}(config=self.mock_config)
-    
-    def test_skill_initialization(self) -> None:
-        """Test {proposal.name} initialization."""
-        assert isinstance(self.skill, {skill_class_name})
-        assert hasattr(self.skill, 'config')
-    
-    def test_skill_execute_basic_action(self) -> None:
-        """Test {proposal.name} execution with basic action."""
-        action = AgentAction(type=ActionType.MESSAGE, text="Test action")
-        observation = self.skill.execute(action)
-        
-        assert isinstance(observation, Observation)
-        assert observation.success is True
-        assert "Executed {proposal.name}" in observation.output
-    
-    def test_skill_analyze_data(self) -> None:
-        """Test {proposal.name} data analysis."""
-        test_data = {"key": "value"}
-        result = self.skill.analyze(test_data)
-        
-        assert isinstance(result, dict)
-        assert "analysis_result" in result
-    
-    def test_skill_suggest_improvements(self) -> None:
-        """Test {proposal.name} improvement suggestions."""
-        suggestions = self.skill.suggest_improvements()
-        
-        assert isinstance(suggestions, list)
-        assert len(suggestions) > 0
+            class Test{skill_class_name}:
+                """Tests for {proposal.name}."""
 
-'''
-        return test_implementation
+                def setup_method(self) -> None:
+                    """Setup before each test."""
+                    self.mock_config = Mock(spec=AgentConfig)
+                    self.mock_config.workspace = Mock()
+                    self.mock_config.workspace.root = Path("/tmp/test")
+                    self.mock_config.policies = Mock()
+                    self.mock_config.policies.allow_network = False
+                    self.mock_config.policies.deny_commands = []
+                    self.mock_config.audit = Mock()
+                    self.mock_config.audit.enable_file_log = True
+                    self.mock_config.audit.file_dir = Path("seed/changes")
+                    self.mock_config.audit.enable_git_commit = False
+                    self.mock_config.audit.commit_prefix = "A3X"
+                    self.skill = {skill_class_name}(config=self.mock_config)
+
+                def test_skill_initialization(self) -> None:
+                    """Test {proposal.name} initialization."""
+                    assert isinstance(self.skill, {skill_class_name})
+                    assert hasattr(self.skill, "config")
+
+                def test_skill_execute_basic_action(self) -> None:
+                    """Test {proposal.name} execution with basic action."""
+                    action = AgentAction(type=ActionType.MESSAGE, text="Test action")
+                    observation = self.skill.execute(action)
+
+                    assert isinstance(observation, Observation)
+                    assert observation.success is True
+                    assert "Executed {proposal.name}" in observation.output
+
+                def test_skill_analyze_data(self) -> None:
+                    """Test {proposal.name} data analysis."""
+                    test_data = {{"key": "value"}}
+                    result = self.skill.analyze(test_data)
+
+                    assert isinstance(result, dict)
+                    assert "analysis_result" in result
+
+                def test_skill_suggest_improvements(self) -> None:
+                    """Test {proposal.name} improvement suggestions."""
+                    suggestions = self.skill.suggest_improvements()
+
+                    assert isinstance(suggestions, list)
+                    assert len(suggestions) > 0
+            '''
+        ).strip("\n")
+        return f"{test_implementation}\n"

--- a/tests/unit/a3x/skills/test_skill_creator.py
+++ b/tests/unit/a3x/skills/test_skill_creator.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from a3x.meta_capabilities import SkillProposal
+from a3x.skills.skill_creator import SkillCreator
+
+
+def _build_fake_proposal() -> SkillProposal:
+    return SkillProposal(
+        id="skill.fake",
+        name="Fake Skill",
+        description="Uma skill fake apenas para testes.",
+        implementation_plan="Implementação mínima",
+        required_dependencies=["pytest"],
+        estimated_effort=1.0,
+        priority="low",
+        rationale="Cobrir casos de teste",
+        target_domain="testing",
+        created_at="2024-01-01T00:00:00Z",
+    )
+
+
+def test_skill_creator_generates_files(tmp_path: Path) -> None:
+    creator = SkillCreator(tmp_path)
+    proposal = _build_fake_proposal()
+
+    success, message = creator.create_skill_from_proposal(proposal)
+
+    assert success, message
+
+    skill_slug = proposal.name.lower().replace(" ", "_").replace("-", "_")
+    skill_path = tmp_path / "a3x" / "skills" / f"{skill_slug}.py"
+    test_path = (
+        tmp_path
+        / "tests"
+        / "unit"
+        / "a3x"
+        / "skills"
+        / f"test_{skill_slug}.py"
+    )
+
+    assert skill_path.exists(), f"Skill file not created: {message}"
+    assert test_path.exists(), "Test file not created"
+
+    assert "Fake Skill" in skill_path.read_text(encoding="utf-8")
+    assert "Tests for Fake Skill" in test_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- converter skill_creator em módulo Python real com imports explícitos e geração formatada de implementações e testes
- garantir que as strings geradas tenham conteúdo válido, incluindo placeholders e retornos seguros
- adicionar teste unitário que valida a criação dos arquivos de skill e teste a partir de uma proposta fake

## Testing
- PYTHONPATH=. pytest tests/unit/a3x/test_meta_capabilities.py tests/unit/a3x/skills/


------
https://chatgpt.com/codex/tasks/task_e_68dc7e8231d08320a3c5d59494e9a46d