### PR TITLE
feat: priorizar seeds por fitness adaptativo

### DIFF
--- a/a3x/agent.py
+++ b/a3x/agent.py
@@ -25,6 +25,7 @@ class AgentResult:
     failures: int
     history: AgentHistory
     errors: List[str]
+    memories_reused: int = 0
 
 
 class AgentOrchestrator:
@@ -111,6 +112,7 @@ class AgentOrchestrator:
                     failures=failures,
                     history=history,
                     errors=errors,
+                    memories_reused=self._estimate_memories_reused(history),
                 )
                 self._record_auto_evaluation(goal, result, started_at)
                 return result
@@ -123,6 +125,7 @@ class AgentOrchestrator:
             failures=failures,
             history=history,
             errors=errors,
+            memories_reused=self._estimate_memories_reused(history),
         )
         self._record_auto_evaluation(goal, result, started_at)
         return result
@@ -156,6 +159,26 @@ class AgentOrchestrator:
             aggregated[f"{key}_last"] = values[-1]
             aggregated[f"{key}_avg"] = sum(values) / len(values)
         return aggregated
+
+    def _estimate_memories_reused(self, history: AgentHistory) -> int:
+        count = 0
+        for event in history.events:
+            for metadata in (event.action.metadata or {}, event.observation.metadata or {}):
+                if not metadata:
+                    continue
+                if "memories_reused" in metadata:
+                    try:
+                        count += int(metadata.get("memories_reused", 0))
+                    except (TypeError, ValueError):
+                        count += 1
+                elif "memory_hits" in metadata:
+                    try:
+                        count += int(metadata.get("memory_hits", 0))
+                    except (TypeError, ValueError):
+                        count += 1
+                elif metadata.get("memory") == "reused":
+                    count += 1
+        return count
 
     def _record_auto_evaluation(
         self, goal: str, result: AgentResult, started_at: float
@@ -287,6 +310,7 @@ class AgentOrchestrator:
         metrics["failures"] = float(result.failures)
         metrics["iterations"] = float(result.iterations)
         metrics["recursion_depth"] = float(self.recursion_depth)
+        metrics["memories_reused"] = float(result.memories_reused)
 
         test_runs = [
             event
@@ -331,18 +355,3 @@ def _infer_extension(action: AgentAction) -> str | None:
             path = match.group("path")
             return Path(path).suffix.lstrip(".") or None
     return None
-
-    def _capture_llm_metrics(self) -> None:
-        metrics = self.llm_client.get_last_metrics()
-        for key, value in metrics.items():
-            if isinstance(value, (int, float)):
-                self._llm_metrics.setdefault(key, []).append(float(value))
-
-    def _aggregate_llm_metrics(self) -> Dict[str, float]:
-        aggregated: Dict[str, float] = {}
-        for key, values in self._llm_metrics.items():
-            if not values:
-                continue
-            aggregated[f"{key}_last"] = values[-1]
-            aggregated[f"{key}_avg"] = sum(values) / len(values)
-        return aggregated

--- a/a3x/seed_runner.py
+++ b/a3x/seed_runner.py
@@ -19,6 +19,8 @@ class SeedRunResult:
     status: str
     completed: bool
     notes: str = ""
+    iterations: int = 0
+    memories_reused: int = 0
 
 
 class SeedRunner:
@@ -52,14 +54,34 @@ class SeedRunner:
         if result.errors:
             notes = "; ".join(result.errors)
         if result.completed:
-            self.backlog.mark_completed(seed.id, notes=notes)
+            self.backlog.mark_completed(
+                seed.id,
+                notes=notes,
+                iterations=result.iterations,
+                memories_reused=result.memories_reused,
+            )
             return SeedRunResult(
-                seed_id=seed.id, status="completed", completed=True, notes=notes
+                seed_id=seed.id,
+                status="completed",
+                completed=True,
+                notes=notes,
+                iterations=result.iterations,
+                memories_reused=result.memories_reused,
             )
 
-        self.backlog.mark_failed(seed.id, notes=notes or "Seed não concluída")
+        self.backlog.mark_failed(
+            seed.id,
+            notes=notes or "Seed não concluída",
+            iterations=result.iterations,
+            memories_reused=result.memories_reused,
+        )
         return SeedRunResult(
-            seed_id=seed.id, status="failed", completed=False, notes=notes
+            seed_id=seed.id,
+            status="failed",
+            completed=False,
+            notes=notes,
+            iterations=result.iterations,
+            memories_reused=result.memories_reused,
         )
 
 

--- a/tests/integration/test_seed_runner.py
+++ b/tests/integration/test_seed_runner.py
@@ -29,7 +29,12 @@ def test_seed_runner_success_flow(tmp_path: Path) -> None:
     runner = SeedRunner.__new__(SeedRunner)
     runner.backlog = backlog_mock
 
-    orchestrator_result = SimpleNamespace(completed=True, errors=[])
+    orchestrator_result = SimpleNamespace(
+        completed=True,
+        errors=[],
+        iterations=4,
+        memories_reused=2,
+    )
 
     with patch("a3x.seed_runner.load_config") as mock_load_config, patch(
         "a3x.seed_runner.build_llm_client"
@@ -49,8 +54,15 @@ def test_seed_runner_success_flow(tmp_path: Path) -> None:
 
     assert isinstance(result, SeedRunResult)
     assert result.completed is True
+    assert result.iterations == orchestrator_result.iterations
+    assert result.memories_reused == orchestrator_result.memories_reused
     backlog_mock.mark_in_progress.assert_called_once()
-    backlog_mock.mark_completed.assert_called_once()
+    backlog_mock.mark_completed.assert_called_once_with(
+        "seed-1",
+        notes="",
+        iterations=orchestrator_result.iterations,
+        memories_reused=orchestrator_result.memories_reused,
+    )
 
 
 def test_seed_runner_failure_marks_seed(tmp_path: Path) -> None:
@@ -61,7 +73,12 @@ def test_seed_runner_failure_marks_seed(tmp_path: Path) -> None:
     runner = SeedRunner.__new__(SeedRunner)
     runner.backlog = backlog_mock
 
-    orchestrator_result = SimpleNamespace(completed=False, errors=["timeout"])
+    orchestrator_result = SimpleNamespace(
+        completed=False,
+        errors=["timeout"],
+        iterations=7,
+        memories_reused=0,
+    )
 
     with patch("a3x.seed_runner.load_config") as mock_load_config, patch(
         "a3x.seed_runner.build_llm_client"
@@ -80,5 +97,12 @@ def test_seed_runner_failure_marks_seed(tmp_path: Path) -> None:
 
     assert isinstance(result, SeedRunResult)
     assert result.completed is False
-    backlog_mock.mark_failed.assert_called_once()
+    assert result.notes == "timeout"
+    assert result.iterations == orchestrator_result.iterations
+    backlog_mock.mark_failed.assert_called_once_with(
+        "seed-2",
+        notes="timeout",
+        iterations=orchestrator_result.iterations,
+        memories_reused=orchestrator_result.memories_reused,
+    )
     backlog_mock.mark_completed.assert_not_called()


### PR DESCRIPTION
## Summary
- rastreia métricas da última execução nas seeds e persiste o fitness derivado no backlog
- calcula fitness com base em prioridade, tentativas e ganho esperado para ordenar próximas seeds
- propaga iterações/memórias reutilizadas no AgentOrchestrator e SeedRunner e ajusta testes de integração

## Testing
- pytest -q *(falha: dependências numpy, hypothesis e pandas ausentes no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68dc80f87d788320b06eebe1283bf1a7