### PR TITLE
feat: orquestrar criação de skills a partir das seeds

### DIFF
--- a/a3x/skills/skill_creator.py
+++ b/a3x/skills/skill_creator.py
@@ -1,120 +1,134 @@
-"""
+"""Ferramentas para materializar habilidades a partir de propostas."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from textwrap import dedent
+from typing import Tuple
+
+from ..meta_capabilities import SkillProposal
+
+
 class SkillCreator:
-    """Creates actual skill implementations from proposals."""
-    
+    """Cria implementações reais de skills com base em propostas aprovadas."""
+
     def __init__(self, workspace_root: Path) -> None:
         self.workspace_root = workspace_root
         self.skills_dir = workspace_root / "a3x" / "skills"
+        self.tests_dir = workspace_root / "tests" / "unit" / "a3x" / "skills"
+        self.registry_dir = workspace_root / "seed" / "skills"
         self.skills_dir.mkdir(parents=True, exist_ok=True)
-    
+        self.tests_dir.mkdir(parents=True, exist_ok=True)
+        self.registry_dir.mkdir(parents=True, exist_ok=True)
+
     def create_skill_from_proposal(self, proposal: SkillProposal) -> Tuple[bool, str]:
-        """
-        Create an actual skill implementation from a proposal.
-        Returns (success, message).
-        """
+        """Materializa uma skill e seus testes a partir de uma proposta."""
+        slug = self._slugify(proposal.name)
+        skill_path = self.skills_dir / f"{slug}.py"
+        test_path = self.tests_dir / f"test_{slug}.py"
+
         try:
-            # Generate the skill implementation code
-            implementation = self._generate_skill_implementation(proposal)
-            
-            # Save the skill to a file
-            skill_filename = f"{proposal.name.lower().replace(' ', '_').replace('-', '_')}.py"
-            skill_path = self.skills_dir / skill_filename
-            
-            # Write the implementation to file
+            implementation = self._resolve_implementation(proposal)
             skill_path.write_text(implementation, encoding="utf-8")
-            
-            # Create test file for the new skill
-            test_filename = f"test_{proposal.name.lower().replace(' ', '_').replace('-', '_')}.py"
-            test_path = self.workspace_root / "tests" / "unit" / "a3x" / "skills" / test_filename
-            test_path.parent.mkdir(parents=True, exist_ok=True)
-            
-            test_implementation = self._generate_skill_test(proposal, skill_filename)
-            test_path.write_text(test_implementation, encoding="utf-8")
-            
-            return True, f"Skill '{proposal.name}' created successfully at {skill_path}"
-            
-        except Exception as e:
-            return False, f"Failed to create skill '{proposal.name}': {str(e)}"
-    
+
+            test_content = self._generate_skill_test(proposal, slug)
+            test_path.write_text(test_content, encoding="utf-8")
+
+            self._register_skill(proposal, slug, skill_path, test_path)
+            message = (
+                f"Skill '{proposal.name}' criada em "
+                f"{skill_path.relative_to(self.workspace_root)}"
+                f" com testes em {test_path.relative_to(self.workspace_root)}"
+            )
+            return True, message
+        except Exception as exc:  # pragma: no cover - protegido em testes específicos
+            return False, f"Falha ao criar skill '{proposal.name}': {exc}"
+
+    def _resolve_implementation(self, proposal: SkillProposal) -> str:
+        if proposal.blueprint_path:
+            blueprint_path = Path(proposal.blueprint_path)
+            if not blueprint_path.is_absolute():
+                blueprint_path = self.workspace_root / blueprint_path
+            if not blueprint_path.exists():
+                raise FileNotFoundError(
+                    f"Blueprint não encontrada em {blueprint_path}"
+                )
+            return blueprint_path.read_text(encoding="utf-8")
+        return self._generate_skill_implementation(proposal)
+
     def _generate_skill_implementation(self, proposal: SkillProposal) -> str:
-        """Generate the actual implementation code for a skill."""
-        # Create a basic skill template
-        implementation = f'''"""{proposal.description}"""
+        class_name = proposal.name.replace(" ", "").replace("-", "")
+        description = proposal.description or "Implementação de skill gerada automaticamente."
+        escaped_description = description.replace("\"", "\\\"")
+        skill_label = proposal.name.replace("\"", "\\\"")
+        return dedent(
+            f'''"""{escaped_description}"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
-from pathlib import Path
+from typing import Dict, List
 
 from ..actions import AgentAction, Observation
 from ..config import AgentConfig
 
 
 @dataclass
-class {proposal.name.replace(" ", "").replace("-", "")}:
-    """{proposal.description}"""
-    
+class {class_name}:
+    """{description}"""
+
     config: AgentConfig
-    # Add skill-specific fields based on proposal
     capabilities: List[str] = field(default_factory=list)
-    
+
     def __post_init__(self) -> None:
-        """Initialize skill-specific components."""
         self._initialize_components()
-    
+
     def _initialize_components(self) -> None:
-        """Initialize skill-specific components."""
-        # Implementation goes here based on proposal requirements
-        pass
-    
+        """Inicializa componentes específicos da skill."""
+        # TODO: Personalizar inicialização com base no plano da proposta
+
     def execute(self, action: AgentAction) -> Observation:
-        """Execute the skill."""
+        """Executa a skill com a ação fornecida."""
         try:
-            # Implementation based on proposal
             result = self._perform_action(action)
             return Observation(success=True, output=result)
-        except Exception as e:
-            return Observation(success=False, error=str(e))
-    
+        except Exception as exc:  # pragma: no cover - comportamento defensivo
+            return Observation(success=False, error=str(exc))
+
     def _perform_action(self, action: AgentAction) -> str:
-        """Perform the specific action for this skill."""
-        # Actual implementation would go here
-        # For now, return a placeholder result
-        return f"Executed {proposal.name} with action: {action.text or 'no text'}"
-    
-    def analyze(self, data: Dict[str, any]) -> Dict[str, any]:
-        """Analyze data related to this skill."""
-        # Analysis implementation based on proposal
+        """Implementa a lógica específica da skill."""
+        return f"Executed {skill_label} with action: {{action.text or 'no text'}}"
+
+    def analyze(self, data: Dict[str, object]) -> Dict[str, object]:
+        """Realiza análises auxiliares previstas na proposta."""
         return {"analysis_result": "placeholder"}
-    
+
     def suggest_improvements(self) -> List[str]:
-        """Suggest improvements for this skill."""
-        # Improvement suggestions based on proposal
+        """Sugere evoluções para a skill."""
         return ["Implement core functionality", "Add more comprehensive tests"]
-
 '''
-        return implementation
-    
-    def _generate_skill_test(self, proposal: SkillProposal, skill_filename: str) -> str:
-        """Generate a test file for the skill."""
-        skill_class_name = proposal.name.replace(" ", "").replace("-", "")
-        test_implementation = f'''"""Tests for {proposal.name} skill."""
+        )
 
-import pytest
-from unittest.mock import Mock, patch
+    def _generate_skill_test(self, proposal: SkillProposal, slug: str) -> str:
+        class_name = proposal.name.replace(" ", "").replace("-", "")
+        skill_label = proposal.name.replace("\"", "\\\"")
+        return dedent(
+            f'''"""Testes automáticos para a skill {proposal.name}."""
+
+from unittest.mock import Mock
 from pathlib import Path
 
-from a3x.skills.{skill_filename[:-3]} import {skill_class_name}
+from a3x.skills.{slug} import {class_name}
 from a3x.actions import AgentAction, ActionType, Observation
 from a3x.config import AgentConfig
 
 
-class Test{skill_class_name}:
-    """Tests for {proposal.name}."""
-    
+class Test{class_name}:
+    """Cenários básicos de validação da skill."""
+
     def setup_method(self) -> None:
-        """Setup before each test."""
         self.mock_config = Mock(spec=AgentConfig)
         self.mock_config.workspace = Mock()
         self.mock_config.workspace.root = Path("/tmp/test")
@@ -126,36 +140,70 @@ class Test{skill_class_name}:
         self.mock_config.audit.file_dir = Path("seed/changes")
         self.mock_config.audit.enable_git_commit = False
         self.mock_config.audit.commit_prefix = "A3X"
-        self.skill = {skill_class_name}(config=self.mock_config)
-    
+        self.skill = {class_name}(config=self.mock_config)
+
     def test_skill_initialization(self) -> None:
-        """Test {proposal.name} initialization."""
-        assert isinstance(self.skill, {skill_class_name})
-        assert hasattr(self.skill, 'config')
-    
+        assert isinstance(self.skill, {class_name})
+        assert hasattr(self.skill, "config")
+
     def test_skill_execute_basic_action(self) -> None:
-        """Test {proposal.name} execution with basic action."""
         action = AgentAction(type=ActionType.MESSAGE, text="Test action")
         observation = self.skill.execute(action)
-        
+
         assert isinstance(observation, Observation)
         assert observation.success is True
-        assert "Executed {proposal.name}" in observation.output
-    
+        assert "Executed {skill_label}" in observation.output
+
     def test_skill_analyze_data(self) -> None:
-        """Test {proposal.name} data analysis."""
-        test_data = {"key": "value"}
-        result = self.skill.analyze(test_data)
-        
+        result = self.skill.analyze({"key": "value"})
+
         assert isinstance(result, dict)
         assert "analysis_result" in result
-    
+
     def test_skill_suggest_improvements(self) -> None:
-        """Test {proposal.name} improvement suggestions."""
         suggestions = self.skill.suggest_improvements()
-        
+
         assert isinstance(suggestions, list)
         assert len(suggestions) > 0
-
 '''
-        return test_implementation
+        )
+
+    def _register_skill(
+        self,
+        proposal: SkillProposal,
+        slug: str,
+        skill_path: Path,
+        test_path: Path,
+    ) -> None:
+        record_path = self.registry_dir / f"{proposal.id}.json"
+        if record_path.exists():
+            try:
+                record = json.loads(record_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                record = {}
+        else:
+            record = asdict(proposal)
+
+        record.update(
+            {
+                "id": proposal.id,
+                "name": proposal.name,
+                "slug": slug,
+                "description": proposal.description,
+                "skill_path": str(skill_path.relative_to(self.workspace_root)),
+                "test_path": str(test_path.relative_to(self.workspace_root)),
+                "blueprint_path": proposal.blueprint_path,
+                "status": "implemented",
+            }
+        )
+
+        record_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _slugify(value: str) -> str:
+        normalized = "".join(ch if ch.isalnum() else "_" for ch in value.lower())
+        normalized = normalized.strip("_")
+        return normalized or "nova_skill"

--- a/tests/integration/test_seed_runner.py
+++ b/tests/integration/test_seed_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -72,6 +73,137 @@ def test_seed_runner_failure_marks_seed(tmp_path: Path) -> None:
         )
         mock_build_llm.return_value = Mock()
         mock_orchestrator.return_value.run.return_value = orchestrator_result
+
+        result = SeedRunner.run_next(
+            runner,
+            default_config=tmp_path / "config.yaml",
+        )
+
+    assert isinstance(result, SeedRunResult)
+    assert result.completed is False
+    backlog_mock.mark_failed.assert_called_once()
+    backlog_mock.mark_completed.assert_not_called()
+
+
+def test_seed_runner_skill_creation_success(tmp_path: Path) -> None:
+    proposal_dir = tmp_path / "seed" / "skills"
+    proposal_dir.mkdir(parents=True, exist_ok=True)
+    proposal_path = proposal_dir / "proposal.json"
+    proposal_path.write_text(
+        json.dumps(
+            {
+                "id": "skill_proposal_001",
+                "name": "Test Skill",
+                "description": "Habilidade gerada via seed",
+                "implementation_plan": "Detalhes da implementação",
+                "required_dependencies": ["core.diffing"],
+                "estimated_effort": 3.0,
+                "priority": "high",
+                "rationale": "Cobrir lacuna",
+                "target_domain": "testing",
+                "created_at": "2024-10-10T00:00:00Z",
+                "blueprint_path": "seed/skills/skill_proposal_001.py",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    seed = _build_seed(
+        id="skill-seed",
+        type="skill_creation",
+        metadata={
+            "proposal_record": str(proposal_path.relative_to(tmp_path)),
+        },
+    )
+
+    backlog_mock = Mock()
+    backlog_mock.next_seed.return_value = seed
+
+    runner = SeedRunner.__new__(SeedRunner)
+    runner.backlog = backlog_mock
+
+    orchestrator_result = SimpleNamespace(completed=True, errors=[])
+
+    with patch("a3x.seed_runner.load_config") as mock_load_config, patch(
+        "a3x.seed_runner.build_llm_client"
+    ) as mock_build_llm, patch("a3x.seed_runner.AgentOrchestrator") as mock_orchestrator, patch.object(
+        Path, "cwd", return_value=tmp_path
+    ), patch("a3x.seed_runner.SkillCreator") as mock_skill_creator:
+        mock_load_config.return_value = SimpleNamespace(
+            limits=SimpleNamespace(max_iterations=5),
+            llm=Mock(),
+        )
+        mock_build_llm.return_value = Mock()
+        mock_instance = mock_orchestrator.return_value
+        mock_instance.run.return_value = orchestrator_result
+        creator_instance = mock_skill_creator.return_value
+        creator_instance.create_skill_from_proposal.return_value = (True, "ok")
+
+        result = SeedRunner.run_next(
+            runner,
+            default_config=tmp_path / "config.yaml",
+        )
+
+    creator_instance.create_skill_from_proposal.assert_called_once()
+    proposal_arg = creator_instance.create_skill_from_proposal.call_args[0][0]
+    assert proposal_arg.id == "skill_proposal_001"
+    assert isinstance(result, SeedRunResult)
+    assert result.completed is True
+    backlog_mock.mark_completed.assert_called_once()
+
+
+def test_seed_runner_skill_creation_failure_marks_backlog(tmp_path: Path) -> None:
+    proposal_dir = tmp_path / "seed" / "skills"
+    proposal_dir.mkdir(parents=True, exist_ok=True)
+    proposal_path = proposal_dir / "proposal.json"
+    proposal_path.write_text(
+        json.dumps(
+            {
+                "id": "skill_proposal_002",
+                "name": "Skill Failure",
+                "description": "Proposta que falha",
+                "implementation_plan": "Plano",
+                "required_dependencies": ["core.testing"],
+                "estimated_effort": 2.0,
+                "priority": "medium",
+                "rationale": "Teste",
+                "target_domain": "analysis",
+                "created_at": "2024-10-11T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    seed = _build_seed(
+        id="skill-seed-fail",
+        type="skill_creation",
+        metadata={
+            "proposal_record": str(proposal_path.relative_to(tmp_path)),
+        },
+    )
+
+    backlog_mock = Mock()
+    backlog_mock.next_seed.return_value = seed
+
+    runner = SeedRunner.__new__(SeedRunner)
+    runner.backlog = backlog_mock
+
+    orchestrator_result = SimpleNamespace(completed=True, errors=[])
+
+    with patch("a3x.seed_runner.load_config") as mock_load_config, patch(
+        "a3x.seed_runner.build_llm_client"
+    ) as mock_build_llm, patch("a3x.seed_runner.AgentOrchestrator") as mock_orchestrator, patch.object(
+        Path, "cwd", return_value=tmp_path
+    ), patch("a3x.seed_runner.SkillCreator") as mock_skill_creator:
+        mock_load_config.return_value = SimpleNamespace(
+            limits=SimpleNamespace(max_iterations=5),
+            llm=Mock(),
+        )
+        mock_build_llm.return_value = Mock()
+        mock_instance = mock_orchestrator.return_value
+        mock_instance.run.return_value = orchestrator_result
+        creator_instance = mock_skill_creator.return_value
+        creator_instance.create_skill_from_proposal.return_value = (False, "erro")
 
         result = SeedRunner.run_next(
             runner,

--- a/tests/unit/a3x/skills/test_skill_creator.py
+++ b/tests/unit/a3x/skills/test_skill_creator.py
@@ -1,0 +1,75 @@
+"""Testes para a rotina de criação de skills a partir de propostas."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from a3x.meta_capabilities import SkillProposal
+from a3x.skills.skill_creator import SkillCreator
+
+
+def _base_proposal(**overrides) -> SkillProposal:
+    data = {
+        "id": "skill_proposal_test",
+        "name": "Test Skill",
+        "description": "Skill para testes automatizados",
+        "implementation_plan": "Executar plano de teste",
+        "required_dependencies": ["core.testing"],
+        "estimated_effort": 1.5,
+        "priority": "high",
+        "rationale": "Cobrir lacuna de testes",
+        "target_domain": "testing",
+        "created_at": "2024-10-10T00:00:00Z",
+        "blueprint_path": None,
+    }
+    data.update(overrides)
+    return SkillProposal(**data)
+
+
+def test_skill_creator_uses_blueprint_when_available(tmp_path: Path) -> None:
+    blueprint = tmp_path / "seed" / "skills" / "skill_proposal_test.py"
+    blueprint.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_content = "class Generated:\n    pass\n"
+    blueprint.write_text(blueprint_content, encoding="utf-8")
+
+    creator = SkillCreator(tmp_path)
+    proposal = _base_proposal(blueprint_path=str(blueprint.relative_to(tmp_path)))
+
+    success, message = creator.create_skill_from_proposal(proposal)
+
+    assert success is True
+    assert "Skill 'Test Skill'" in message
+
+    skill_path = tmp_path / "a3x" / "skills" / "test_skill.py"
+    test_path = tmp_path / "tests" / "unit" / "a3x" / "skills" / "test_test_skill.py"
+    registry_path = tmp_path / "seed" / "skills" / f"{proposal.id}.json"
+
+    assert skill_path.exists()
+    assert skill_path.read_text(encoding="utf-8") == blueprint_content
+    assert test_path.exists()
+    assert registry_path.exists()
+
+    registry_data = json.loads(registry_path.read_text(encoding="utf-8"))
+    assert registry_data["slug"] == "test_skill"
+    assert registry_data["skill_path"] == "a3x/skills/test_skill.py"
+    assert registry_data["status"] == "implemented"
+
+
+def test_skill_creator_generates_template_without_blueprint(tmp_path: Path) -> None:
+    creator = SkillCreator(tmp_path)
+    proposal = _base_proposal(blueprint_path=None)
+
+    success, message = creator.create_skill_from_proposal(proposal)
+
+    assert success is True
+    assert "Skill 'Test Skill'" in message
+
+    skill_path = tmp_path / "a3x" / "skills" / "test_skill.py"
+    test_path = tmp_path / "tests" / "unit" / "a3x" / "skills" / "test_test_skill.py"
+    registry_path = tmp_path / "seed" / "skills" / f"{proposal.id}.json"
+
+    assert skill_path.exists()
+    assert "class TestSkill" in skill_path.read_text(encoding="utf-8")
+    assert test_path.exists()
+    assert registry_path.exists()


### PR DESCRIPTION
## Summary
- adiciona suporte no SeedRunner para processar seeds do tipo skill_creation, carregando propostas e delegando ao SkillCreator
- expande o SkillCreator para usar blueprints quando disponíveis, gerar testes e registrar a skill criada no catálogo seed/skills
- cria testes de integração e unidade garantindo o fluxo de criação de skills e a geração dos artefatos correspondentes

## Testing
- pytest -q *(falha: dependências opcionais numpy/pandas/hypothesis ausentes no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68dc80ff043883209e0f6d5ad4b02f5e