### PR TITLE
feat: integrar currículo ao autoavaliador

### DIFF
--- a/seed/curriculum.yaml
+++ b/seed/curriculum.yaml
@@ -1,0 +1,31 @@
+steps:
+  - id: bootstrap-tests
+    title: "Domínio de testes básicos"
+    difficulty: easy
+    goal: "Garantir que a suíte de testes básica execute sem falhas e documentar o fluxo."
+    description: |
+      Revisar o projeto, executar `pytest -q` e corrigir pequenos problemas para obter uma
+      execução verde. Documentar no relatório como reproduzir o resultado.
+    success_criteria:
+      - "pytest -q executa sem falhas"
+      - "Relatório de execução atualizado em seed/reports"
+  - id: reinforce-quality
+    title: "Melhorar qualidade de código"
+    difficulty: medium
+    goal: "Introduzir melhorias de linting e automatizar validações em seeds existentes."
+    description: |
+      Ajustar seeds/manuais para disparar lint automático e capturar métricas de qualidade.
+      Deve incluir ajustes em pipelines de seeds e atualizar documentação relevante.
+    success_criteria:
+      - "Lint automático habilitado em seeds prioritárias"
+      - "Novas métricas de qualidade registradas em seed/reports"
+  - id: self-directed-evolution
+    title: "Orquestrar evolução autônoma"
+    difficulty: hard
+    goal: "Configurar ciclo de self-play que proponha e execute seeds de evolução contínua."
+    description: |
+      Utilizar planners/módulos de missão para acoplar currículo com geração de seeds e
+      validar se o agente é capaz de criar, executar e avaliar melhorias em sequência.
+    success_criteria:
+      - "Seed de self-play enfileirada e executada"
+      - "Relatório do ciclo com auto-crítica registrada"


### PR DESCRIPTION
## Resumo
- adiciona seed/curriculum.yaml com trilha de tarefas progressiva para self-play
- estende AutoEvaluator para gerar auto-crítica pós-reflexão, registrar progresso do currículo e enfileirar a próxima seed

## Testes
- pytest -q *(falhou: dependências opcionais ausentes - numpy, hypothesis, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68dc81031d948320a590a625c6ee5ddd