### PR TITLE
feat: suportar roteiro determinístico no run

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ a3x run --goal "Adicionar endpoint /health" --config configs/sample.yaml
 
 O arquivo `configs/sample.yaml` está pronto para usar o modelo Grok 4 Fast via OpenRouter (`llm.model: "x-ai/grok-4-fast:free"`). Ajuste o campo `llm.model` conforme o slug desejado listado em <https://openrouter.ai/models>. Caso queira testar o ciclo sem chamadas externas, utilize `configs/manual.yaml`, que trabalha com scripts previamente definidos em `configs/scripts/demo_plan.yaml`.
 
+Para reproduções determinísticas sem depender de OpenRouter, force o uso do `ManualLLMClient` passando um roteiro explícito:
+
+```bash
+a3x run --goal "Rodar script determinístico" --config configs/sample.yaml --deterministic-script scripts/demo.yaml
+```
+
+Quando a flag `--deterministic-script` não é informada, a execução segue normalmente com as configurações declaradas no arquivo YAML (ex.: OpenRouter).
+
 ### Execução de Seeds Autônomas
 
 ```bash

--- a/a3x/cli.py
+++ b/a3x/cli.py
@@ -35,6 +35,10 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument(
         "--show-history", action="store_true", help="Exibe histórico completo ao final"
     )
+    run_parser.add_argument(
+        "--deterministic-script",
+        help="Força execução determinística via ManualLLMClient usando roteiro YAML",
+    )
     # Auto-watch: roda o daemon de seeds após a execução principal
     run_parser.add_argument(
         "--auto-watch",
@@ -280,6 +284,17 @@ def main(argv: list[str] | None = None) -> int:
     config = load_config(args.config)
     if args.max_steps:
         config.limits.max_iterations = args.max_steps
+
+    if args.deterministic_script:
+        script_path = Path(args.deterministic_script)
+        if not script_path.is_absolute():
+            script_path = script_path.resolve()
+        config.llm.type = "manual"
+        config.llm.script = script_path
+        config.llm.model = None
+        config.llm.endpoint = None
+        config.llm.base_url = None
+        config.llm.api_key_env = None
 
     llm_client = build_llm_client(config.llm)
     orchestrator = AgentOrchestrator(config, llm_client)

--- a/scripts/demo.yaml
+++ b/scripts/demo.yaml
@@ -1,0 +1,4 @@
+- type: message
+  text: "Iniciando execução determinística"
+- type: finish
+  text: "Execução determinística concluída"


### PR DESCRIPTION
## Summary
- adiciona flag `--deterministic-script` ao subcomando `run` para acionar o ManualLLMClient
- sobrescreve configuração do LLM quando a flag é usada, preservando o comportamento padrão com OpenRouter
- documenta o fluxo determinístico no README e adiciona um roteiro de exemplo em `scripts/demo.yaml`

## Testing
- pytest -q *(falha: dependências opcionais numpy, hypothesis e pandas não estão disponíveis no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68dc81051f7c832099c1011493a6d2a6