### PR TITLE
feat: planejamento hierárquico e retroalimentação automática

### DIFF
--- a/a3x/llm_seed_strategist.py
+++ b/a3x/llm_seed_strategist.py
@@ -1,0 +1,78 @@
+"""Generate backlog seeds directly from runtime failures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from hashlib import md5
+from pathlib import Path
+from typing import List
+
+from .actions import AgentAction, Observation
+from .seeds import Seed, SeedBacklog
+
+
+@dataclass
+class FailureEvent:
+    goal: str
+    action_type: str
+    description: str
+    snippet: str
+
+    def seed_id(self) -> str:
+        digest = md5(f"{self.goal}|{self.action_type}|{self.description}".encode("utf-8")).hexdigest()
+        return f"auto-failure.{digest[:10]}"
+
+
+@dataclass
+class LLMSeedStrategist:
+    """Track executor failures and turn them into actionable seeds."""
+
+    backlog_path: Path
+    _events: List[FailureEvent] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.backlog_path = Path(self.backlog_path)
+
+    def capture_failure(self, goal: str, action: AgentAction, observation: Observation) -> None:
+        snippet = (observation.output or observation.error or "").strip()
+        if len(snippet) > 400:
+            snippet = snippet[:397] + "..."
+        description = observation.error or "Falha sem descrição"
+        event = FailureEvent(
+            goal=goal,
+            action_type=action.type.name,
+            description=description,
+            snippet=snippet,
+        )
+        self._events.append(event)
+
+    def flush(self) -> List[Seed]:
+        if not self._events:
+            return []
+        backlog = SeedBacklog.load(self.backlog_path)
+        created: List[Seed] = []
+        for event in self._events:
+            seed_id = event.seed_id()
+            if backlog.exists(seed_id):
+                continue
+            seed = Seed(
+                id=seed_id,
+                goal=f"Investigar falha: {event.description}",
+                priority="high",
+                status="pending",
+                type="failure",
+                metadata={
+                    "source": "llm_failure_capture",
+                    "action_type": event.action_type,
+                    "goal": event.goal,
+                    "snippet": event.snippet,
+                },
+            )
+            backlog.add_seed(seed)
+            created.append(seed)
+        backlog.save()
+        self._events.clear()
+        return created
+
+
+__all__ = ["LLMSeedStrategist"]

--- a/a3x/planning/__init__.py
+++ b/a3x/planning/__init__.py
@@ -11,6 +11,7 @@ from .mission_state import (
     MissionTelemetry,
 )
 from .mission_planner import MissionPlanner
+from .hierarchical_planner import HierarchicalPlanner, GoalPlan, MissionPlan, TaskPlan
 
 __all__ = [
     "MissionState",
@@ -22,4 +23,8 @@ __all__ = [
     "MilestoneStatus",
     "MetricSnapshot",
     "MissionPlanner",
+    "HierarchicalPlanner",
+    "GoalPlan",
+    "MissionPlan",
+    "TaskPlan",
 ]

--- a/a3x/planning/hierarchical_planner.py
+++ b/a3x/planning/hierarchical_planner.py
@@ -1,0 +1,522 @@
+"""Hierarchical planning utilities for the autonomous loop.
+
+This module introduces a Goal -> Mission -> Task decomposition that can be
+persisted between runs.  The implementation favors explicit data classes and a
+minimal persistence format (JSON) so that humans can audit or resume a plan at
+any point in time.
+
+The planner builds plans from three main sources:
+
+* The current :class:`~a3x.actions.AgentState` (gives the goal and the latest
+  context summary).
+* The mission backlog (``MissionState``) maintained by the auto evaluator.
+* Operational objectives configured at runtime (e.g. high-level goals chosen
+  by the user or by the seed backlog).
+
+Plans are stored under ``seed/memory/plans/<slug>.json`` together with a small
+execution journal.  Every update keeps a full snapshot to simplify debugging.
+
+The planner is intentionally deterministic so that it is easy to assert on its
+behaviour during tests – we reuse the same ordering rules that the mission
+planner follows and we expose a compact public API:
+
+``ensure_plan``
+    Load or build a plan for the provided state.
+
+``record_action_result``
+    Update the tracked step with the observation coming from the executor.  It
+    returns a :class:`PlanEvaluation` object that callers can use to trigger a
+    replan or to raise alerts.
+
+``force_replan``
+    Discard the current plan and recompute a fresh tree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+import json
+import textwrap
+
+from ..actions import ActionType, AgentAction, AgentState, Observation
+from ..planner import PlannerThresholds
+from ..planning.mission_state import MissionMilestone, MissionState
+
+
+@dataclass
+class PlanEvidence:
+    """Evidence attached to a step.
+
+    Evidence items represent objective confirmations that a step was completed
+    (for instance, the output of a test command or a summary of a diff).
+    """
+
+    type: str
+    description: str
+    payload: Optional[str] = None
+
+
+@dataclass
+class TaskPlan:
+    """Leaf of the hierarchical planner."""
+
+    id: str
+    description: str
+    expected_outcome: str
+    metrics_target: Dict[str, float] = field(default_factory=dict)
+    status: str = "pending"  # pending|in_progress|completed|blocked
+    dependencies: List[str] = field(default_factory=list)
+    evidence: List[PlanEvidence] = field(default_factory=list)
+    last_observation: Optional[str] = None
+    blocked_reason: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        payload = asdict(self)
+        payload["evidence"] = [asdict(item) for item in self.evidence]
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "TaskPlan":
+        evidence_raw = data.get("evidence") or []
+        evidence = [PlanEvidence(**item) for item in evidence_raw if isinstance(item, dict)]
+        return cls(
+            id=str(data.get("id")),
+            description=str(data.get("description", "")),
+            expected_outcome=str(data.get("expected_outcome", "")),
+            metrics_target={
+                str(k): float(v)
+                for k, v in (data.get("metrics_target") or {}).items()
+                if isinstance(v, (int, float))
+            },
+            status=str(data.get("status", "pending")),
+            dependencies=list(data.get("dependencies", []) or []),
+            evidence=evidence,
+            last_observation=(
+                str(data.get("last_observation")) if data.get("last_observation") else None
+            ),
+            blocked_reason=(
+                str(data.get("blocked_reason")) if data.get("blocked_reason") else None
+            ),
+        )
+
+    def mark_in_progress(self) -> None:
+        if self.status == "pending":
+            self.status = "in_progress"
+
+    def mark_completed(self, observation: str, evidence: Iterable[PlanEvidence]) -> None:
+        self.status = "completed"
+        self.last_observation = observation
+        self.evidence.extend(evidence)
+        self.blocked_reason = None
+
+    def mark_blocked(self, reason: str, observation: str | None = None) -> None:
+        self.status = "blocked"
+        self.blocked_reason = reason
+        if observation:
+            self.last_observation = observation
+
+
+@dataclass
+class MissionPlan:
+    """A mission contains a set of ordered tasks."""
+
+    id: str
+    description: str
+    priority: str
+    tasks: List[TaskPlan]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "priority": self.priority,
+            "tasks": [task.to_dict() for task in self.tasks],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "MissionPlan":
+        return cls(
+            id=str(data.get("id")),
+            description=str(data.get("description", "")),
+            priority=str(data.get("priority", "medium")),
+            tasks=[TaskPlan.from_dict(item) for item in data.get("tasks", []) or []],
+        )
+
+    def next_task(self) -> Optional[TaskPlan]:
+        for task in self.tasks:
+            if task.status in {"pending", "in_progress"}:
+                return task
+        return None
+
+
+@dataclass
+class PlanEvent:
+    timestamp: float
+    step_id: str
+    action_type: str
+    status: str
+    notes: str
+
+
+@dataclass
+class GoalPlan:
+    """Root object describing the active plan for a goal."""
+
+    goal: str
+    missions: List[MissionPlan]
+    plan_id: str
+    metrics_snapshot: Dict[str, float] = field(default_factory=dict)
+    current_mission: Optional[str] = None
+    current_task: Optional[str] = None
+    events: List[PlanEvent] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "goal": self.goal,
+            "missions": [mission.to_dict() for mission in self.missions],
+            "plan_id": self.plan_id,
+            "metrics_snapshot": self.metrics_snapshot,
+            "current_mission": self.current_mission,
+            "current_task": self.current_task,
+            "events": [asdict(event) for event in self.events],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "GoalPlan":
+        events = [PlanEvent(**item) for item in data.get("events", []) or [] if isinstance(item, dict)]
+        return cls(
+            goal=str(data.get("goal", "")),
+            missions=[MissionPlan.from_dict(item) for item in data.get("missions", []) or []],
+            plan_id=str(data.get("plan_id", "")),
+            metrics_snapshot={
+                str(k): float(v)
+                for k, v in (data.get("metrics_snapshot") or {}).items()
+                if isinstance(v, (int, float))
+            },
+            current_mission=(
+                str(data.get("current_mission")) if data.get("current_mission") else None
+            ),
+            current_task=(
+                str(data.get("current_task")) if data.get("current_task") else None
+            ),
+            events=events,
+        )
+
+    def locate_step(self, step_id: str | None) -> Optional[TaskPlan]:
+        if step_id is None:
+            return None
+        for mission in self.missions:
+            for task in mission.tasks:
+                if task.id == step_id:
+                    return task
+        return None
+
+    def update_current_step(self) -> None:
+        for mission in self.missions:
+            task = mission.next_task()
+            if task:
+                self.current_mission = mission.id
+                self.current_task = task.id
+                task.mark_in_progress()
+                return
+        self.current_mission = None
+        self.current_task = None
+
+
+@dataclass
+class PlanEvaluation:
+    """Result of evaluating an action against the plan."""
+
+    needs_replan: bool = False
+    alerts: List[str] = field(default_factory=list)
+
+    def register_alert(self, message: str) -> None:
+        self.alerts.append(message)
+        if "replanejamento" in message or "falhou" in message:
+            self.needs_replan = True
+
+
+def _slugify(text: str) -> str:
+    return "".join(ch.lower() if ch.isalnum() else "-" for ch in text).strip("-") or "goal"
+
+
+class HierarchicalPlanner:
+    """Main entry-point for hierarchical planning."""
+
+    def __init__(
+        self,
+        storage_dir: Path | str = Path("seed/memory/plans"),
+        *,
+        thresholds: Optional[PlannerThresholds] = None,
+    ) -> None:
+        self.storage_dir = Path(storage_dir)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.thresholds = thresholds or PlannerThresholds()
+        self._cached_plan: Optional[GoalPlan] = None
+
+    # ------------------------------------------------------------------ public
+    def ensure_plan(
+        self,
+        state: AgentState,
+        missions: Optional[MissionState],
+        objectives: Sequence[str],
+        metrics_history: Dict[str, List[float]],
+    ) -> GoalPlan:
+        plan_id = _slugify(state.goal)
+        plan = self._load_plan(plan_id)
+        if plan is None or self._metrics_degraded(plan, metrics_history):
+            plan = self._build_plan(state, missions, objectives, metrics_history)
+            self._save_plan(plan)
+        plan.update_current_step()
+        self._cached_plan = plan
+        return plan
+
+    def force_replan(
+        self,
+        state: AgentState,
+        missions: Optional[MissionState],
+        objectives: Sequence[str],
+        metrics_history: Dict[str, List[float]],
+    ) -> GoalPlan:
+        plan = self._build_plan(state, missions, objectives, metrics_history)
+        self._save_plan(plan)
+        self._cached_plan = plan
+        return plan
+
+    def record_action_result(
+        self,
+        action: AgentAction,
+        observation: Observation,
+        timestamp: float,
+    ) -> PlanEvaluation:
+        if self._cached_plan is None:
+            return PlanEvaluation()
+        plan = self._cached_plan
+        step = plan.locate_step(plan.current_task)
+        evaluation = PlanEvaluation()
+        if step is None:
+            evaluation.register_alert("Nenhum passo ativo para avaliar – replanejamento sugerido.")
+            return evaluation
+
+        observation_excerpt = (observation.output or "").strip()
+        if len(observation_excerpt) > 400:
+            observation_excerpt = observation_excerpt[:397] + "..."
+
+        if observation.success:
+            evidence = self._build_evidence(action, observation_excerpt)
+            step.mark_completed(observation_excerpt, evidence)
+        else:
+            reason = observation.error or "Ação falhou sem descrição."
+            step.mark_blocked(reason, observation_excerpt)
+            evaluation.register_alert(f"Passo {step.id} falhou: {reason}. replanejamento sugerido")
+
+        plan.events.append(
+            PlanEvent(
+                timestamp=timestamp,
+                step_id=step.id,
+                action_type=action.type.name,
+                status=step.status,
+                notes=observation.error or observation_excerpt or "sem saída",
+            )
+        )
+        plan.update_current_step()
+        self._save_plan(plan)
+        return evaluation
+
+    def current_plan(self) -> Optional[GoalPlan]:
+        return self._cached_plan
+
+    # ----------------------------------------------------------------- helpers
+    def _build_plan(
+        self,
+        state: AgentState,
+        missions: Optional[MissionState],
+        objectives: Sequence[str],
+        metrics_history: Dict[str, List[float]],
+    ) -> GoalPlan:
+        mission_plans: List[MissionPlan] = []
+        if missions:
+            for mission in missions.missions:
+                description = mission.vision or f"Missão {mission.id}"
+                mission_plan = MissionPlan(
+                    id=str(mission.id),
+                    description=description,
+                    priority=mission.priority,
+                    tasks=self._convert_milestones(mission.milestones),
+                )
+                mission_plans.append(mission_plan)
+
+        if not mission_plans:
+            # Fallback: create a minimal mission with generic steps so that the
+            # orchestrator always has guidance.
+            fallback_tasks = self._build_fallback_tasks(state.goal)
+            mission_plans.append(
+                MissionPlan(
+                    id="fallback",
+                    description="Explorar objetivo corrente",
+                    priority="medium",
+                    tasks=fallback_tasks,
+                )
+            )
+
+        plan_id = _slugify(state.goal)
+        plan = GoalPlan(
+            goal=state.goal,
+            missions=mission_plans,
+            plan_id=plan_id,
+            metrics_snapshot=self._latest_metrics(metrics_history),
+        )
+        plan.update_current_step()
+        return plan
+
+    def _convert_milestones(self, milestones: List[MissionMilestone]) -> List[TaskPlan]:
+        tasks: List[TaskPlan] = []
+        for milestone in milestones:
+            if milestone.status == "completed":
+                continue
+            task_id = f"{milestone.id}"
+            description = milestone.goal or f"Milestone {milestone.id}"
+            metrics = {
+                metric: snapshot.target
+                for metric, snapshot in milestone.metrics.items()
+                if snapshot.target is not None
+            }
+            expected = textwrap.dedent(
+                (
+                    milestone.notes
+                    or "Preparar alteração, implementar e validar com testes automatizados."
+                )
+            ).strip()
+            tasks.append(
+                TaskPlan(
+                    id=task_id,
+                    description=description,
+                    expected_outcome=expected,
+                    metrics_target=metrics,
+                    dependencies=list(milestone.dependencies or []),
+                )
+            )
+        return tasks
+
+    def _build_fallback_tasks(self, goal: str) -> List[TaskPlan]:
+        return [
+            TaskPlan(
+                id="analisar",
+                description="Analisar contexto e estabelecer hipóteses",
+                expected_outcome=f"Entendimento claro do objetivo '{goal}' e plano de execução",
+            ),
+            TaskPlan(
+                id="executar",
+                description="Implementar mudanças principais",
+                expected_outcome="Alterações aplicadas com diffs revisados",
+                dependencies=["analisar"],
+            ),
+            TaskPlan(
+                id="validar",
+                description="Executar testes e validações",
+                expected_outcome="Resultados de testes documentados",
+                dependencies=["executar"],
+            ),
+            TaskPlan(
+                id="documentar",
+                description="Documentar aprendizados",
+                expected_outcome="Insights e documentação atualizados",
+                dependencies=["validar"],
+            ),
+        ]
+
+    def _latest_metrics(self, metrics_history: Dict[str, List[float]]) -> Dict[str, float]:
+        snapshot: Dict[str, float] = {}
+        for name, values in metrics_history.items():
+            if values:
+                snapshot[name] = float(values[-1])
+        return snapshot
+
+    def _metrics_degraded(
+        self, plan: GoalPlan, metrics_history: Dict[str, List[float]]
+    ) -> bool:
+        if not plan.metrics_snapshot:
+            return False
+        for name, baseline in plan.metrics_snapshot.items():
+            latest_values = metrics_history.get(name)
+            if not latest_values:
+                continue
+            latest = latest_values[-1]
+            if baseline == 0:
+                continue
+            variation = (baseline - latest) / abs(baseline)
+            if variation >= 0.25:  # drop of 25% from baseline triggers replan
+                return True
+        return False
+
+    def _build_evidence(
+        self, action: AgentAction, observation_excerpt: str
+    ) -> List[PlanEvidence]:
+        evidence: List[PlanEvidence] = []
+        if action.type == ActionType.RUN_COMMAND:
+            evidence.append(
+                PlanEvidence(
+                    type="command_output",
+                    description=f"Comando '{action.command}' executado",
+                    payload=observation_excerpt,
+                )
+            )
+        elif action.type == ActionType.APPLY_PATCH:
+            evidence.append(
+                PlanEvidence(
+                    type="patch_applied",
+                    description="Patch aplicado com sucesso",
+                    payload=observation_excerpt,
+                )
+            )
+        elif action.type == ActionType.WRITE_FILE:
+            evidence.append(
+                PlanEvidence(
+                    type="file_written",
+                    description=f"Arquivo {action.path} atualizado",
+                    payload=observation_excerpt,
+                )
+            )
+        elif action.type == ActionType.FINISH:
+            evidence.append(
+                PlanEvidence(
+                    type="finish",
+                    description="Fluxo encerrado pelo LLM",
+                    payload=observation_excerpt,
+                )
+            )
+        return evidence
+
+    # --------------------------------------------------------------- persistence
+    def _plan_path(self, plan_id: str) -> Path:
+        return self.storage_dir / f"{plan_id}.json"
+
+    def _load_plan(self, plan_id: str) -> Optional[GoalPlan]:
+        path = self._plan_path(plan_id)
+        if not path.exists():
+            return None
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+        plan = GoalPlan.from_dict(raw)
+        return plan
+
+    def _save_plan(self, plan: GoalPlan) -> None:
+        path = self._plan_path(plan.plan_id)
+        payload = plan.to_dict()
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+__all__ = [
+    "PlanEvidence",
+    "TaskPlan",
+    "MissionPlan",
+    "PlanEvent",
+    "GoalPlan",
+    "PlanEvaluation",
+    "HierarchicalPlanner",
+]

--- a/a3x/policy.py
+++ b/a3x/policy.py
@@ -1,0 +1,77 @@
+"""Policy override helpers fed by retrospective insights."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Any, TYPE_CHECKING
+
+import yaml
+
+from .memory.insights import RetrospectiveReport
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .agent import AgentOrchestrator
+
+
+@dataclass
+class PolicyOverrideManager:
+    """Persist overrides derived from self-evaluation feedback."""
+
+    path: Path = field(default_factory=lambda: Path("configs/policy_overrides.yaml"))
+    data: Dict[str, Any] = field(init=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+        self.data = self._load()
+
+    # ---------------------------------------------------------------- public
+    def apply_to_agent(self, agent: "AgentOrchestrator") -> None:
+        overrides = self.data.get("agent", {})
+        recursion_depth = overrides.get("recursion_depth")
+        if recursion_depth is not None:
+            try:
+                agent.recursion_depth = int(recursion_depth)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                pass
+        max_failures = overrides.get("max_failures")
+        if max_failures is not None:
+            try:
+                agent.config.limits.max_failures = int(max_failures)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                pass
+
+    def update_from_report(self, report: RetrospectiveReport, agent: "AgentOrchestrator") -> None:
+        overrides = dict(self.data.get("agent", {}))
+        updated = False
+        for recommendation in report.recommendations:
+            if "Reduzir profundidade recursiva" in recommendation:
+                overrides["recursion_depth"] = max(3, agent.recursion_depth - 1)
+                updated = True
+            if "aumentar supervisão" in recommendation:
+                overrides["max_failures"] = max(3, agent.config.limits.max_failures - 1)
+                updated = True
+        if updated:
+            self.data["agent"] = overrides
+            self._save()
+            self.apply_to_agent(agent)
+
+    # --------------------------------------------------------------- internals
+    def _load(self) -> Dict[str, Any]:
+        if not self.path.exists():
+            return {}
+        try:
+            loaded = yaml.safe_load(self.path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError:
+            return {}
+        if not isinstance(loaded, dict):
+            return {}
+        return loaded
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(self.data, handle, allow_unicode=True, sort_keys=False)
+
+
+__all__ = ["PolicyOverrideManager"]

--- a/configs/policy_overrides.yaml
+++ b/configs/policy_overrides.yaml
@@ -1,0 +1,4 @@
+# Ajustes derivados de retrospectivas automáticas.
+agent:
+  recursion_depth: 3
+  max_failures: 10

--- a/tests/unit/a3x/planning/test_hierarchical_planner.py
+++ b/tests/unit/a3x/planning/test_hierarchical_planner.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from a3x.actions import ActionType, AgentAction, AgentState, Observation
+from a3x.planning.hierarchical_planner import HierarchicalPlanner
+
+
+def _state(goal: str = "Melhorar docs") -> AgentState:
+    return AgentState(goal=goal, history_snapshot="", iteration=1, max_iterations=5)
+
+
+def test_ensure_plan_persists_structure(tmp_path):
+    planner = HierarchicalPlanner(storage_dir=tmp_path)
+    plan = planner.ensure_plan(_state(), missions=None, objectives=[], metrics_history={})
+
+    assert plan.current_task == "analisar"
+    stored_path = tmp_path / f"{plan.plan_id}.json"
+    assert stored_path.exists()
+    payload = json.loads(stored_path.read_text(encoding="utf-8"))
+    assert payload["missions"][0]["tasks"][0]["status"] == "in_progress"
+
+
+def test_record_action_and_replan_on_metric_drop(tmp_path):
+    planner = HierarchicalPlanner(storage_dir=tmp_path)
+    metrics_history = {"actions_success_rate": [1.0]}
+    plan = planner.ensure_plan(_state(), missions=None, objectives=[], metrics_history=metrics_history)
+
+    action = AgentAction(type=ActionType.RUN_COMMAND, command=["pytest"])
+    observation = Observation(success=True, output="ok")
+    planner.record_action_result(action, observation, timestamp=1.0)
+
+    stored_before = json.loads((tmp_path / f"{plan.plan_id}.json").read_text(encoding="utf-8"))
+    first_task = stored_before["missions"][0]["tasks"][0]
+    assert first_task["status"] == "completed"
+
+    degraded_history = {"actions_success_rate": [1.0, 0.5]}
+    replanned = planner.ensure_plan(_state(), missions=None, objectives=[], metrics_history=degraded_history)
+    assert replanned.current_task == "analisar"
+    stored_after = json.loads((tmp_path / f"{replanned.plan_id}.json").read_text(encoding="utf-8"))
+    assert stored_after["missions"][0]["tasks"][0]["status"] == "in_progress"

--- a/tests/unit/a3x/test_llm_seed_strategist.py
+++ b/tests/unit/a3x/test_llm_seed_strategist.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from a3x.actions import ActionType, AgentAction, Observation
+from a3x.llm_seed_strategist import LLMSeedStrategist
+
+
+def test_capture_failure_generates_seed(tmp_path):
+    strategist = LLMSeedStrategist(backlog_path=tmp_path / "backlog.yaml")
+    action = AgentAction(type=ActionType.RUN_COMMAND, command=["pytest"])
+    observation = Observation(success=False, error="pytest falhou")
+
+    strategist.capture_failure("objetivo", action, observation)
+    created = strategist.flush()
+
+    assert created
+    seed = created[0]
+    assert seed.priority == "high"
+    assert "pytest" in seed.goal.lower()
+    backlog_contents = (tmp_path / "backlog.yaml").read_text(encoding="utf-8")
+    assert "llm_failure_capture" in backlog_contents

--- a/tests/unit/a3x/test_policy_overrides.py
+++ b/tests/unit/a3x/test_policy_overrides.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from a3x.memory.insights import RetrospectiveReport
+from a3x.policy import PolicyOverrideManager
+
+
+class DummyAgent(SimpleNamespace):
+    pass
+
+
+def test_apply_and_update_overrides(tmp_path):
+    manager = PolicyOverrideManager(path=tmp_path / "policy.yaml")
+    agent = DummyAgent(recursion_depth=5, config=SimpleNamespace(limits=SimpleNamespace(max_failures=8)))
+
+    manager.data = {"agent": {"recursion_depth": 6, "max_failures": 9}}
+    manager.apply_to_agent(agent)
+    assert agent.recursion_depth == 6
+    assert agent.config.limits.max_failures == 9
+
+    report = RetrospectiveReport(
+        goal="",
+        completed=False,
+        iterations=3,
+        failures=4,
+        duration_seconds=None,
+        metrics={},
+        recommendations=["Reduzir profundidade recursiva", "aumentar supervisão"],
+        notes=[],
+    )
+    manager.update_from_report(report, agent)
+    assert agent.recursion_depth == 5  # 6 - 1
+    assert agent.config.limits.max_failures == 8  # 9 - 1
+    saved = (tmp_path / "policy.yaml").read_text(encoding="utf-8")
+    assert "recursion_depth" in saved


### PR DESCRIPTION
## Resumo
- adiciona planner hierárquico com persistência em seed/memory/plans e avaliação pós-ação
- integra o AgentOrchestrator com retroalimentação automática, políticas ajustáveis e geração de seeds por falhas
- registra retrospectivas versionadas e arquivo de overrides para ajustes operacionais

## Testes
- pytest tests/unit/a3x/planning/test_hierarchical_planner.py tests/unit/a3x/test_policy_overrides.py tests/unit/a3x/test_llm_seed_strategist.py

------
https://chatgpt.com/codex/tasks/task_e_68dca03c0ef0832094a2eb76cadf18bb