### PR TITLE
fix: respeitar zero em métricas de lint e patch

### DIFF
--- a/a3x/metrics.py
+++ b/a3x/metrics.py
@@ -26,8 +26,8 @@ def compute_overall_success_rate(
     rates = {
         "actions_success": actions_rate or 0.0,
         "tests_success": tests_rate or 0.0,
-        "lint_success": lint_rate or 1.0,
-        "patch_success": patch_rate or 1.0,
+        "lint_success": lint_rate if lint_rate is not None else 1.0,
+        "patch_success": patch_rate if patch_rate is not None else 1.0,
     }
     weights = {
         "actions_success": 0.4,

--- a/tests/unit/a3x/test_metrics.py
+++ b/tests/unit/a3x/test_metrics.py
@@ -17,28 +17,27 @@ def test_get_latest_metric():
 
 def test_compute_overall_success_rate():
     # All rates provided
-    rate = compute_overall_success_rate(0.8, 0.9, 0.95, 0.85)
-    assert rate == 0.855  # 0.4*0.8 + 0.3*0.9 + 0.15*0.95 + 0.15*0.85
+    rate_all_provided = compute_overall_success_rate(0.8, 0.9, 0.95, 0.85)
+    assert rate_all_provided == 0.86  # Weighted sum rounded to 3 decimals
 
     # Some None, defaults to 0 or 1
-    rate = compute_overall_success_rate(0.7, None, None, None)
-    assert rate == 0.355  # 0.4*0.7 + 0.3*0.0 + 0.15*1.0 + 0.15*1.0
+    rate_with_defaults = compute_overall_success_rate(0.7, None, None, None)
+    assert rate_with_defaults == 0.58
 
     # Edge case: all None
-    rate = compute_overall_success_rate()
-    assert rate == 0.7  # 0.4*0 + 0.3*0 + 0.15*1 + 0.15*1 = 0.3, wait no:
-    # actions=0, tests=0, lint=1, patch=1 -> 0.4*0 + 0.3*0 + 0.15*1 + 0.15*1 = 0.3
-    # But let's calculate properly in code.
-
-    # Zero actions edge case
-    rate = compute_overall_success_rate(0.0, 1.0, 1.0, 1.0)
-    assert rate == 0.3  # 0.4*0 + 0.3*1 + 0.15*1 + 0.15*1 = 0.6? Wait, fix calculation.
-
-# Note: Actual calculation in function: actions=0.4, tests=0.3, lint=0.15, patch=0.15
-# For all None: actions=0, tests=0, lint=1, patch=1 -> 0 + 0 + 0.15 + 0.15 = 0.3
     rate_all_none = compute_overall_success_rate()
     assert rate_all_none == 0.3
 
-    # Zero actions
-    rate_zero_actions = compute_overall_success_rate(0.0, 0.9, 0.95, 0.85)
-    assert rate_zero_actions == 0.555  # 0.4*0 + 0.3*0.9 + 0.15*0.95 + 0.15*0.85
+    # Zero actions edge case
+    rate_zero_actions_full_success = compute_overall_success_rate(0.0, 1.0, 1.0, 1.0)
+    assert rate_zero_actions_full_success == 0.6
+
+    rate_zero_actions_partial_success = compute_overall_success_rate(0.0, 0.9, 0.95, 0.85)
+    assert rate_zero_actions_partial_success == 0.54
+
+    # Lint or patch failure should not default to 1.0
+    rate_zero_lint = compute_overall_success_rate(1.0, 1.0, 0.0, 1.0)
+    assert rate_zero_lint == 0.85
+
+    rate_zero_patch = compute_overall_success_rate(1.0, 1.0, 1.0, 0.0)
+    assert rate_zero_patch == 0.85


### PR DESCRIPTION
## Summary
- evita que compute_overall_success_rate trate 0.0 em lint ou patch como sucesso implícito
- ajusta os testes de métricas para refletir os pesos corretos e cobrir falhas explícitas

## Testing
- PYTHONPATH=. pytest tests/unit/a3x/test_metrics.py -q


------
https://chatgpt.com/codex/tasks/task_e_68ddfb82f27483209f22704c3eaa76f6